### PR TITLE
Dependency upgrade for PHP8 compatability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "MIT"
   ],
   "require" : {
-    "abraham/twitteroauth": "^0.5.3"
+    "abraham/twitteroauth": "^2.0.2"
   },
   "autoload" : {
     "psr-0" : {


### PR DESCRIPTION
I have upgraded dependency version of abraham/twitteroauth to ^2.0.2 for compatability with PHP8